### PR TITLE
Don't download through GitHub api

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -38,4 +38,4 @@ ln -s /config/PlexRequests.sqlite /app/PlexRequests.Net/PlexRequests.sqlite
 ln -s /config/Backup /app/PlexRequests.Net/Backup
 
 cd /app/PlexRequests.Net
-mono PlexRequests.exe
+mono PlexRequests.exe "${RUN_OPTS}"

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-plex_remote="$(curl -sX GET https://api.github.com/repos/tidusjar/PlexRequests.Net/releases/latest | awk '/browser_download_url/{print $4;exit}' FS='[""]')"
+identifier="tidusjar/PlexRequests.Net"
+filename="PlexRequests.zip"
+output_path="/tmp/plexrequestsnet.zip"
 
 # check for original config file in app dir
 if [ -f /app/PlexRequests.Net/PlexRequests.sqlite && ! -f /config/PlexRequests.Net/PlexRequests.sqlite ]; then
@@ -12,7 +14,7 @@ rm -rf /app/PlexRequests.Net
 if [ "$DEV" = "1" ]; then
   python /get-dev.py
 else
-  curl -o /tmp/plexrequestsnet.zip -L "$plex_remote"
+  curl -s -L https://github.com/$identifier/releases/latest | egrep -o "/$identifier/releases/download/v[0-9\.]*/$filename" | wget --base=http://github.com/ -i - -O $output_path
 fi
 unzip -o /tmp/plexrequestsnet.zip -d /tmp
 


### PR DESCRIPTION
Download PlexRequests.net through the Github website rather than the API. The API tends to fail because of rate limiting.

Before this patch, I was unable to install this.