### PR TITLE
Allow option for baseUrl

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -58,7 +58,7 @@ chown -R ombi:ombi /config
 cd /app/Ombi
 
 if [ -z "$BASEURL" ]; then
-  exec s6-setuidgid ombi mono Ombi.exe -b "$BASEURL" "${RUN_OPTS}"
-else
   exec s6-setuidgid ombi mono Ombi.exe "${RUN_OPTS}"
+else
+  exec s6-setuidgid ombi mono Ombi.exe -b "$BASEURL" "${RUN_OPTS}"
 fi

--- a/start.sh
+++ b/start.sh
@@ -56,4 +56,9 @@ chown -R ombi:ombi /app
 chown -R ombi:ombi /config
 
 cd /app/Ombi
-exec s6-setuidgid ombi mono Ombi.exe "${RUN_OPTS}"
+
+if [ -z "$BASEURL" ]; then
+  exec s6-setuidgid ombi mono Ombi.exe -b "$BASEURL" "${RUN_OPTS}"
+else
+  exec s6-setuidgid ombi mono Ombi.exe "${RUN_OPTS}"
+fi


### PR DESCRIPTION
For example:
`-e BASEURL=ombi`

Fixes: #14 