### PR TITLE
Add EAP support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM mono:4.6.2
 
 MAINTAINER rogueosb@gmail.com
 
-ENV APTLIST="ca-certificates-mono bzip2 libcurl4-openssl-dev wget unzip sqlite3 python2.7"
+ENV APTLIST="ca-certificates-mono bzip2 libcurl4-openssl-dev wget unzip sqlite3 python"
 
 # install packages
 RUN apt-get update -q && \
@@ -27,6 +27,7 @@ usermod -G users ombi
 
 ADD start.sh /start.sh
 ADD get-dev.py /get-dev.py
+ADD get-eap.py /get-eap.py
 RUN chmod +x /start.sh
 
 # ports and volumes

--- a/get-eap.py
+++ b/get-eap.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python2.7
+import sys
+import urllib
+import urllib2
+import json
+
+apiurl = "https://ci.appveyor.com/api/projects/tidusjar/requestplex"
+headers = {"Content-Type":"application/json"}
+
+request = urllib2.Request(apiurl + "/history?recordsNumber=10&branch=eap")
+
+for key,value in headers.items():
+  request.add_header(key,value)
+
+response = urllib2.urlopen(request)
+
+json1 = json.loads(response.read())
+
+for build in json1["builds"]:
+  if build["status"] == "success":
+    request = urllib2.Request(apiurl + "/build/" + str(build["version"]))
+    json2 = json.loads(urllib2.urlopen(request).read())
+    with open('/tmp/Ombi.zip','wb') as f:
+      f.write(urllib2.urlopen("https://ci.appveyor.com/api/buildjobs/" + json2["build"]["jobs"][0]["jobId"] + "/artifacts/Ombi.zip").read())
+      f.close()
+    break

--- a/start.sh
+++ b/start.sh
@@ -23,9 +23,14 @@ ombi_remote=$(curl $user_details -sX GET https://api.github.com/repos/$identifie
 rm -rf /app/Ombi
 
 if [ "$DEV" = "1" ]; then
-  python /get-dev.py
+  echo "Getting Development Version";
+  /usr/bin/python /get-dev.py
+elif [ "$EAP" = "1" ]; then
+  echo "Getting Early Access Preview";
+  /usr/bin/python /get-eap.py
 else
-  curl -o $zip_path -L "$ombi_remote"
+  echo "Getting Stable Version";
+  /usr/bin/curl -o $zip_path -L "$ombi_remote"
 fi
 
 unzip -o $zip_path -d /tmp


### PR DESCRIPTION
Added EAP support.

1. Renamed python2.7 to python in the apt env.
2. copied get-dev to get-eap and edited the endings to get the eap file instead
3. added it to start.sh

Works perfectly well for me. Also fixes #16 